### PR TITLE
Bug fixed on jsonEncode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.9
+
+- Bug fixed on jsonEncode(Model)
+
 ## 1.1.8
 
 - Update readme

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import '../dox_query_builder.dart';
 
 class Model<T> extends QueryBuilder<T> {
@@ -87,14 +85,14 @@ class Model<T> extends QueryBuilder<T> {
   // Model to json string converter
   ///
   /// ```
-  /// String blog = Blog().find(1).toJson();
+  /// Map<String, dynamic> blog = Blog().find(1).toJson();
   /// ```
-  String toJson() {
+  Map<String, dynamic> toJson() {
     Map<String, dynamic> data = toMap();
     for (String h in hidden) {
       data.remove(h);
     }
-    return jsonEncode(data);
+    return data;
   }
 
   Map<String, dynamic> toMap(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dox_query_builder
 description: PostgresSQL query builder, Support Model, Where, orWhere, Find, Join, softDeletes, Debugging and many mores.
-version: 1.1.8
+version: 1.1.9
 repository: https://github.com/dartondox/dox-query-builder
 homepage: https://github.com/dartondox/dox-query-builder
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dox_query_builder
 description: PostgresSQL query builder, Support Model, Where, orWhere, Find, Join, softDeletes, Debugging and many mores.
 version: 1.1.9
 repository: https://github.com/dartondox/dox-query-builder
-homepage: https://github.com/dartondox/dox-query-builder
+homepage: https://dartondox.dev
 
 environment:
   sdk: '>=2.19.0 <4.0.0'

--- a/test/sql_query_builder_test.dart
+++ b/test/sql_query_builder_test.dart
@@ -132,8 +132,8 @@ void main() async {
       blog.description = "something";
       await blog.save();
 
-      String data = blog.toJson();
-      expect(true, data.contains('new blog'));
+      Map<String, dynamic> data = blog.toJson();
+      expect(true, data['title'].contains('new blog'));
     });
 
     test('schema update', () async {


### PR DESCRIPTION
To support `jsonEncode(Model)`, `toJson()` should return map instead of encoded string.